### PR TITLE
Update .NET CDN Quickstart Samples

### DIFF
--- a/cdn/getting-started/samples/authentication.rst
+++ b/cdn/getting-started/samples/authentication.rst
@@ -1,17 +1,20 @@
 .. code-block:: csharp
 
-  using OpenStack.Net;
-  using OpenStack.Services.Identity.V2;
-  using Rackspace.Security.Authentication;
+  using Marvin.JsonPatch;
+  using net.openstack.Core.Domain;
+  using net.openstack.Providers.Rackspace;
+  using OpenStack;
+  using OpenStack.ContentDeliveryNetworks.v1;
+  using System.Collections.Generic;
+  using Flavor = OpenStack.ContentDeliveryNetworks.v1.Flavor;
 
-  IIdentityService idservice =
-    new IdentityClient(new Uri("https://identity.api.rackspacecloud.com"));
-  PasswordCredentials pwdCred =
-    new PasswordCredentials("{username}", "{password}");
-  AuthenticationData authData = new AuthenticationData(pwdCred);
-  AuthenticationRequest request = new AuthenticationRequest(authData);
-  RackspaceAuthenticationService ras =
-    new RackspaceAuthenticationService(idservice, request);
+  var identity = new CloudIdentity
+  {
+      APIKey = "{apikey}",
+      Username = "{username}"
+  };
+  var authProvider = new CloudIdentityProvider(identity);
+  var cdnService = new ContentDeliveryNetworkService(authProvider, "{region}");
 
 .. code-block:: go
 

--- a/cdn/getting-started/samples/authentication.rst
+++ b/cdn/getting-started/samples/authentication.rst
@@ -1,5 +1,6 @@
 .. code-block:: csharp
 
+  // Sample Project @ https://github.com/openstacknetsdk/Demos/tree/master/RackspaceQuickstart
   using Marvin.JsonPatch;
   using net.openstack.Core.Domain;
   using net.openstack.Providers.Rackspace;

--- a/cdn/getting-started/samples/create_service.rst
+++ b/cdn/getting-started/samples/create_service.rst
@@ -1,65 +1,10 @@
 .. code-block:: csharp
 
-  using OpenStack.Services.ContentDelivery.V1;
-  using System.Collections.Immutable;
-
-  ContentDeliveryClient cdc = GetContentDeliveryClient();
-
-  ServiceProtocol serviceProtocol = ServiceProtocol.Http;
-  ServiceDomain sd = new ServiceDomain("www.example.com", serviceProtocol);
-  ImmutableArray<ServiceDomain>.Builder sdbuilder
-    = ImmutableArray.CreateBuilder<ServiceDomain>();
-  sdbuilder.Add(sd);
-  ImmutableArray<ServiceDomain> domains = sdbuilder.ToImmutable();
-
-  ServiceOriginRule sor =
-    new ServiceOriginRule("example.com", "www.example.com");
-  ImmutableArray<ServiceOriginRule>.Builder sorbuilder
-    = ImmutableArray.CreateBuilder<ServiceOriginRule>();
-  sorbuilder.Add(sor);
-  ImmutableArray<ServiceOriginRule> rules = sorbuilder.ToImmutable();
-
-  ServiceOrigin so = new ServiceOrigin("www.example.com", 80, false, rules);
-  ImmutableArray<ServiceOrigin>.Builder sobuilder
-    = ImmutableArray.CreateBuilder<ServiceOrigin>();
-  sobuilder.Add(so);
-  ImmutableArray<ServiceOrigin> origins = sobuilder.ToImmutable();
-
-  ServiceCacheRule scr = new ServiceCacheRule("default", "www.example.com");
-  ImmutableArray<ServiceCacheRule>.Builder scrbuilder
-    = ImmutableArray.CreateBuilder<ServiceCacheRule>();
-  scrbuilder.Add(scr);
-  ImmutableArray<ServiceCacheRule> scrules = scrbuilder.ToImmutable();
-
-  ImmutableArray<ServiceCache>.Builder scbuilder
-    = ImmutableArray.CreateBuilder<ServiceCache>();
-  ServiceCache sc =
-    new ServiceCache("default", new TimeSpan(0, 0, 3600), scrules);
-  scbuilder.Add(sc);
-  ImmutableArray<ServiceCache> caching = scbuilder.ToImmutable();
-  caching = new ImmutableArray<ServiceCache>();
-
-  ImmutableArray<ServiceRestrictionRule>.Builder srrbuilder
-    = ImmutableArray.CreateBuilder<ServiceRestrictionRule>();
-  ServiceRestrictionRule srr
-    = new ServiceRestrictionRule("example.com", "www.example.com");
-  srrbuilder.Add(srr);
-  ImmutableArray<ServiceRestrictionRule> srrules = srrbuilder.ToImmutable();
-  srrules = new ImmutableArray<ServiceRestrictionRule>();
-
-  ImmutableArray<ServiceRestriction>.Builder rbuilder
-    = ImmutableArray.CreateBuilder<ServiceRestriction>();
-  ServiceRestriction sr = new ServiceRestriction("website only", srrules);
-  rbuilder.Add(sr);
-  ImmutableArray<ServiceRestriction> restrictions =
-    rbuilder.ToImmutable();
-  restrictions = new ImmutableArray<ServiceRestriction>();
-
-  ServiceData serviceData =
-    new ServiceData(serviceName, flavorId, domains, origins, caching, restrictions);
-  CancellationToken cn = new CancellationToken();
-
-  ServiceId x = await cdc.AddServiceAsync(serviceData, cn);
+  ServiceDefinition serviceDefinition = new ServiceDefinition("example_site", "{flavorId}",
+      domains: new[] {new ServiceDomain("www.example.com")},
+      origins: new[] {new ServiceOrigin("example.com")});
+  string serviceId = await cdnService.CreateServiceAsync(serviceDefinition);
+  await cdnService.WaitForServiceDeployedAsync(serviceId);
 
 .. code-block:: go
 

--- a/cdn/getting-started/samples/delete_service.rst
+++ b/cdn/getting-started/samples/delete_service.rst
@@ -1,8 +1,7 @@
 .. code-block:: csharp
 
-  ContentDeliveryClient cdc = GetContentDeliveryClient();
-  CancellationToken cn = new CancellationToken();
-  await cdc.RemoveServiceAsync({serviceId}, cn);
+  await cdnService.DeleteServiceAsync("{serviceId}");
+  await cdnService.WaitForServiceDeletedAsync("{serviceId}");
 
 .. code-block:: go
 

--- a/cdn/getting-started/samples/get_flavor.rst
+++ b/cdn/getting-started/samples/get_flavor.rst
@@ -1,7 +1,6 @@
 .. code-block:: csharp
 
-  CancellationToken cn = new CancellationToken();
-  Flavor flavor = await contentDeliverClient.GetFlavorAsync({flavorId}, cn);
+  Flavor flavor = await cdnService.GetFlavorAsync("{flavorId}");
 
 .. code-block:: go
 

--- a/cdn/getting-started/samples/get_service.rst
+++ b/cdn/getting-started/samples/get_service.rst
@@ -1,9 +1,6 @@
 .. code-block:: csharp
 
-  CancellationToken cn = new CancellationToken();
-  var task = contentDeliveryClient.GetServiceAsync({serviceId}, cn);
-  task.Wait();
-  var result = task.Result;
+  Service service = await cdnService.GetServiceAsync("{serviceId}");
 
 .. code-block:: go
 

--- a/cdn/getting-started/samples/list_flavors.rst
+++ b/cdn/getting-started/samples/list_flavors.rst
@@ -1,15 +1,7 @@
 .. code-block:: csharp
 
-  ListFlavorsApiCall t =
-    await contentDeliveryClient.PrepareListFlavorsAsync(CancellationToken.None);
-  using (t)
-  {
-      Tuple<HttpResponseMessage, ReadOnlyCollectionPage<Flavor>> response =
-        await t.SendAsync(CancellationToken.None);
-      ReadOnlyCollection<Flavor> allFlavors =
-        await response.Item2.GetAllPagesAsync(CancellationToken.None, null);
-  }
-  
+  IEnumerable<Flavor> flavors = await cdnService.ListFlavorsAsync();
+
 .. code-block:: go
 
   err := flavors.List(client).EachPage(func(page pagination.Page) (bool, error) {

--- a/cdn/getting-started/samples/list_services.rst
+++ b/cdn/getting-started/samples/list_services.rst
@@ -1,8 +1,6 @@
 .. code-block:: csharp
 
-  CancellationToken cn = new CancellationToken();
-  ReadOnlyCollectionPage<Service> x =
-    await contentDeliveryClient.ListServicesAsync(cn);
+  IPage<Service> services = await cdnService.ListServicesAsync();
 
 .. code-block:: go
 

--- a/cdn/getting-started/samples/purge_all_service_assets.rst
+++ b/cdn/getting-started/samples/purge_all_service_assets.rst
@@ -1,7 +1,6 @@
 .. code-block:: csharp
 
-  CancellationToken cn = new CancellationToken();
-  await contentDeliveryClient.RemoveAssetAsync({serviceId}, cn, deleteAll: true);
+  await cdnService.PurgeCachedAssetsAsync("{serviceId}");
 
 .. code-block:: go
 

--- a/cdn/getting-started/samples/purge_specific_service_asset.rst
+++ b/cdn/getting-started/samples/purge_specific_service_asset.rst
@@ -1,7 +1,6 @@
 .. code-block:: csharp
 
-  CancellationToken cn = new CancellationToken();
-  await cdc.RemoveAssetAsync({serviceId}, cn, {urlOfAsset});
+  await cdnService.PurgeCachedAssetAsync("{serviceId}", "{relativeUrlOfAsset}");
 
 .. code-block:: go
 

--- a/cdn/getting-started/samples/update_service.rst
+++ b/cdn/getting-started/samples/update_service.rst
@@ -1,19 +1,9 @@
 .. code-block:: csharp
 
-  // Get the existing service, and use it's values
-  // to set the updated version, except for the values
-  // you wish to change; in this example, the name.
-
-  CancellationToken cn = new CancellationToken();
-  var task = contentDeliverClient.GetServiceAsync({serviceId}, cn);
-  task.Wait();
-  var result = task.Result;
-  ServiceData before = result;
-  ServiceData after =
-    new ServiceData("{updated_name}", before.FlavorId, before.Domains, before.Origins,
-    before.CachingRules, before.Restrictions);
-  CancellationToken cn2 = new CancellationToken();
-  await contentDeliveryClient.UpdateServiceAsync({serviceId}, after, cn2);
+  var patch = new JsonPatchDocument<ServiceDefinition>();
+  patch.Replace(svc => svc.Name, "newServiceName");
+  await cdnService.UpdateServiceAsync("{serviceId}", patch);
+  await cdnService.WaitForServiceDeployedAsync("{serviceId}");
 
 .. code-block:: go
 

--- a/cloud-servers/getting-started/samples/create_server.rst
+++ b/cloud-servers/getting-started/samples/create_server.rst
@@ -1,6 +1,6 @@
 .. code-block:: csharp
 
-  cloudServersProvider.CreateServer("{server_name}", "{image_id}", "{flavor_id}");
+  NewServer newServer = cloudServersProvider.CreateServer("{server_name}", "{image_id}", "{flavor_id}");
 
 .. code-block:: go
 

--- a/cloud-servers/getting-started/samples/query_server_build.rst
+++ b/cloud-servers/getting-started/samples/query_server_build.rst
@@ -1,9 +1,6 @@
 .. code-block:: csharp
 
-  // You can wait for any number of states, e.g. Active, Reboot, etc.
-  ServerState[] errorStates = new ServerState[1] { ServerState.Active };
-  ServerState[] serverStates = new ServerState[1] { ServerState.Unknown };
-  cloudServersProvider.WaitForServerState("{server_id}", serverStates, errorStates);
+  Server server = cloudServersProvider.WaitForServerActive(newServer.Id);
 
 .. code-block:: go
 


### PR DESCRIPTION
I've updated the .NET CDN Quickstart with sample code to match openstack.net v1.4.

@DonSchenck and I wanted to provide a working C# project so that someone following along at home could simply clone and have the same code from the Quickstart ready to run. The project code is available at https://github.com/openstacknetsdk/Demos/tree/master/RackspaceQuickstart and I have added a comment pointing people to it in the first code snippet.