### PR TITLE
Add a .deconst.json configuration file.

### DIFF
--- a/.deconst.json
+++ b/.deconst.json
@@ -1,0 +1,3 @@
+{
+  "content-id-base": "https://github.com/rackerlabs/docs-quickstart"
+}


### PR DESCRIPTION
deconst/preparer-sphinx#28 introduced a `.deconst.json` file that stores the content ID base directly in the content repositories, to avoid mixups and bad heuristics preventing content from being submitted the way you expect it to be.