### PR TITLE
Add Region to Node.js authentication samples

### DIFF
--- a/cdn/getting-started/samples/authentication.rst
+++ b/cdn/getting-started/samples/authentication.rst
@@ -54,7 +54,8 @@
   var rackspace = pkgcloud.cdn.createClient({
     provider: 'rackspace',
     username: '{username}',
-    apiKey: '{apiKey}'
+    apiKey: '{apiKey}',
+    region: '{region}'
   });
 
 .. code-block:: php

--- a/cloud-databases/getting-started/samples/authentication.rst
+++ b/cloud-databases/getting-started/samples/authentication.rst
@@ -31,7 +31,8 @@
   var rackspace = pkgcloud.database.createClient({
     provider: 'rackspace',
     username: '{username}',
-    apiKey: '{apiKey}'
+    apiKey: '{apiKey}',
+    region: '{region}'
   });
 
 .. code-block:: php


### PR DESCRIPTION
We were missing the `region:` parameter in a few of the node.js authentication code samples for various services. I did a quick audit to ensure that we were at least consistent with the other languages' auth snippets.

Re: #12