### PR TITLE
Link to the Identity developer guide

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -353,7 +353,7 @@
                                    <ul>
                                        <li><a href="http://docs.rackspace.com/auth/api/v2.0/auth-client-devguide/content/QuickStart-000.html">Quick Start</a></li>
                                        <li><a href="http://docs.rackspace.com/auth/api/v2.0/auth-client-devguide/content/API_Operations.html">API Reference</a></li>
-                                       <li><a href="http://docs.rackspace.com/auth/api/v2.0/auth-client-devguide/content/Overview-d1e65.html">Developer Guide</a></li>
+                                       <li><a href="/docs/cloud-identity/v2/developer-guide/">Developer Guide</a></li>
                                    </ul>
                                </div>
                            </div>


### PR DESCRIPTION
Now that the Cloud Identity dev guide isn't a placeholder, link to it from the `/docs` landing page.

/cc @meker12 