### PR TITLE
Updated metrics link references to use v2 URI

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -386,9 +386,9 @@
                            <div class="list">
                                <div class="list-column">
                                    <ul>
-                                       <li><a href="http://docs.rackspace.com/cmet/api/v1.0/cmet-gettingstarted/content/doc-change-history.html">Quick Start</a></li>
-                                       <li><a href="/docs/cloud-metrics/v1/developer-guide/#document-api-reference">API Reference</a></li>
-                                       <li><a href="/docs/cloud-metrics/v1/developer-guide/">Developer Guide</a></li>
+                                       <li><a href="http://docs.rackspace.com/cmet/api/v2.0/cmet-gettingstarted/content/doc-change-history.html">Quick Start</a></li>
+                                       <li><a href="/docs/cloud-metrics/v2/developer-guide/#document-api-reference">API Reference</a></li>
+                                       <li><a href="/docs/cloud-metrics/v2/developer-guide/">Developer Guide</a></li>
                                    </ul>
                                </div>
                            </div>


### PR DESCRIPTION
Correct ed the URI so that doc version matches the service endpoint. Now updating the landing page to point to the updated URI.