### PR TITLE
Cloud Metrics documentation is at /docs/metrics/

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -387,8 +387,8 @@
                                <div class="list-column">
                                    <ul>
                                        <li><a href="http://docs.rackspace.com/cmet/api/v2.0/cmet-gettingstarted/content/doc-change-history.html">Quick Start</a></li>
-                                       <li><a href="/docs/cloud-metrics/v2/developer-guide/#document-api-reference">API Reference</a></li>
-                                       <li><a href="/docs/cloud-metrics/v2/developer-guide/">Developer Guide</a></li>
+                                       <li><a href="/docs/metrics/v2/developer-guide/#document-api-reference">API Reference</a></li>
+                                       <li><a href="/docs/metrics/v2/developer-guide/">Developer Guide</a></li>
                                    </ul>
                                </div>
                            </div>


### PR DESCRIPTION
Not `/docs/cloud-metrics`.

/cc @meker12 