### PR TITLE
Add v1.0 to Cloud Load Balancers heading on landing page in preparation

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -115,7 +115,7 @@
                <div class="card green">
                    <div class="card-content">
                        <div class="card-title">
-                           <h4 id="docs-cloud-load-balancers">Cloud Load Balancers</h4>
+                           <h4 id="docs-cloud-load-balancers">Cloud Load Balancers v1.0</h4>
                        </div>
                        <div class="card-body">
                            <div class="list">


### PR DESCRIPTION
in preparation for addition of Cloud Load Balancers v2 (EA) next week. Cloud Load Balancers v2 (EA) will be a separate entry on the landing page beside CLB v1.0.