### PR TITLE
[Don't merge yet - CLB v2 deploy postponed] Add Cloud Load Balancers v2 (EA) to landing page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -137,6 +137,27 @@
                <div class="card green">
                    <div class="card-content">
                        <div class="card-title">
+                           <h4 id="docs-cloud-load-balancers-v2">Cloud Load Balancers v2 (EA)</h4>
+                       </div>
+                       <div class="card-body">
+                           <div class="list">
+                               <div class="list-column">
+                                   <ul>
+                                       <li><a href="/docs/cloud-load-balancers/v2/developer-guide/#getting-started">Getting Started</a></li>
+                                       <li><a href="/docs/cloud-load-balancers/v2/developer-guide/#developer-guide">Developer Guide</a></li>
+                                       <li><a href="/docs/cloud-load-balancers/v2/developer-guide/#api-reference">API Reference</a></li>
+                                       <li><a href="/docs/cloud-load-balancers/v2/developer-guide/#release-notes">Release Notes</a></li>
+                                   </ul>
+                               </div>
+                           </div>
+                       </div>
+                   </div>
+               </div>
+           </div>
+           <div class="product">
+               <div class="card green">
+                   <div class="card-content">
+                       <div class="card-title">
                            <h4 id="docs-cloud-dns">Cloud DNS</h4>
                        </div>
                        <div class="card-body">


### PR DESCRIPTION
Does not launch until 7/26 if CLB v2 (EA) launches on schedule this week, but please review @smashwilson or @meker12.