### PR TITLE
Update links for Cloud Orchestration

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -504,8 +504,8 @@
                                <div class="list-column">
                                    <ul>
                                        <li><a href="/docs/orchestration/quickstart/">Quickstart</a></li>
-                                       <li><a href="/docs/cloud-orchestration/v1/getting-started>API Getting Started</a></li>
-                                       <li><a href="/docs/cloud-orchestration/v1/api-reference>API Reference</li>
+                                       <li><a href="/docs/cloud-orchestration/v1/getting-started">API Getting Started</a></li>
+                                       <li><a href="/docs/cloud-orchestration/v1/api-reference">API Reference</li>
                                        <li><a href="/docs/cloud-orchestration/v1/release-notes">Release Notes</a></li>
                                        <li><a href="/docs/user-guides/orchestration/">Template User Guide</a></li>
                                        <li><a href="/docs/cloud-orchestration/v1/resources-reference/">Resource Reference</a></li>

--- a/index.rst
+++ b/index.rst
@@ -504,10 +504,10 @@
                                <div class="list-column">
                                    <ul>
                                        <li><a href="/docs/orchestration/quickstart/">Quickstart</a></li>
-                                       <li><a href="/docs/cloud-orchestration/v1/developer-guide/#document-api-reference">API Reference</a></li>
-                                       <li><a href="/docs/cloud-orchestration/v1/developer-guide/#document-release-notes">Release Notes</a></li>
-                                       <li><a href="/docs/cloud-orchestration/v1/developer-guide/">Developer Guide</a></li>
-                                       <li><a href="/docs/user-guides/orchestration/">User Guide</a></li>
+                                       <li><a href="/docs/cloud-orchestration/v1/getting-started>API Getting Started</a></li>
+                                       <li><a href="/docs/cloud-orchestration/v1/api-reference>API Reference</li>
+                                       <li><a href="/docs/cloud-orchestration/v1/release-notes">Release Notes</a></li>
+                                       <li><a href="/docs/user-guides/orchestration/">Template User Guide</a></li>
                                        <li><a href="/docs/cloud-orchestration/v1/resources-reference/">Resource Reference</a></li>
                                    </ul>
                                </div>

--- a/sdk-doc-conventions.rst
+++ b/sdk-doc-conventions.rst
@@ -1,4 +1,5 @@
 :orphan:
+
 # SDK Quickstart documentation conventions
 
 The SDK Quickstart guides are written in a narrative format with the same use
@@ -6,6 +7,7 @@ cases across all the SDKs. For an example of documentation that follows this
 literate flow, see the `Mailgun documentation`_.
 
 .. _Mailgun documentation: http://documentation.mailgun.com/quickstart.html#sending-messages
+
 
 Code blocks go in the following order::
 
@@ -22,6 +24,7 @@ Code blocks go in the following order::
   .. code-block:: ruby
 
   .. code-block:: sh
+
 
 If you want to add code samples for a new language, insert the language
 alphabetically.


### PR DESCRIPTION
Update menu links for Cloud Orchestration to remove developer guide
and reflect URLs for refactored content.
