### PR TITLE
Remove Admin Guide from RPC menus

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -28,7 +28,6 @@
                              <div class="list-column">
                                 <h5>Rackspace Private Cloud v13</h5>
                                   <ul>
-                                    <li><a href="/docs/private-cloud/rpc/v13/rpc-admin/">Administrator Guide</a></li>
                                     <li><a href="/docs/private-cloud/rpc/v13/rpc-faq-external/">Technical FAQ</a></li>
                                     <li><a href="/docs/private-cloud/rpc/v13/rpc-ops/">Operations Guide</a></li>
                                     <li><a href="/docs/private-cloud/rpc/v13/rpc-releasenotes">Release Notes</a></li>
@@ -37,7 +36,6 @@
                                   </ul>
                                 <h5>Rackspace Private Cloud v12</h5>
                                  <ul>
-                                   <li><a href="/docs/private-cloud/rpc/v12/rpc-admin/">Administrator Guide</a></li>
                                    <li><a href="/docs/private-cloud/rpc/v12/rpc-faq-external/">Technical FAQ</a></li>
                                    <li><a href="/docs/private-cloud/rpc/v12/rpc-ops/">Operations Guide</a></li>
                                    <li><a href="/docs/private-cloud/rpc/v12/rpc-releasenotes">Release Notes</a></li>
@@ -46,7 +44,6 @@
                                  </ul>
                                  <h5>Rackspace Private Cloud v11</h5>
                                  <ul>
-                                   <li><a href="/docs/private-cloud/rpc/v11/rpc-admin/">Administrator Guide</a></li>
                                    <li><a href="/docs/private-cloud/rpc/v11/rpc-faq-external/">Technical FAQ</a></li>
                                    <li><a href="/docs/private-cloud/rpc/v11/rpc-ops/">Operations Guide</a></li>
                                    <li><a href="/docs/private-cloud/rpc/v11/rpc-releasenotes">Release Notes</a></li>


### PR DESCRIPTION
Delete references to v13, v12, and v11 retired RPC Admin guide per
https://github.com/rackerlabs/docs-rpc/pull/804 and 
https://github.com/rackerlabs/docs-rpc/issues/805.