### PR TITLE
Remove RPCO upgrade guides from the landing page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -32,7 +32,6 @@
                                     <li><a href="/docs/private-cloud/rpc/v13/rpc-ops/">Operations Guide</a></li>
                                     <li><a href="/docs/private-cloud/rpc/v13/rpc-releasenotes">Release Notes</a></li>
                                     <li><a href="/docs/private-cloud/rpc/v13/rpc-swift">Standalone Object Storage Guide</a></li>
-                                    <li><a href="/docs/private-cloud/rpc/v13/rpc-upgrade">Upgrade Guide</a></li>
                                   </ul>
                                 <h5>Rackspace Private Cloud v12</h5>
                                  <ul>
@@ -40,7 +39,6 @@
                                    <li><a href="/docs/private-cloud/rpc/v12/rpc-ops/">Operations Guide</a></li>
                                    <li><a href="/docs/private-cloud/rpc/v12/rpc-releasenotes">Release Notes</a></li>
                                    <li><a href="/docs/private-cloud/rpc/v12/rpc-swift">Standalone Object Storage Guide</a></li>
-                                   <li><a href="/docs/private-cloud/rpc/v12/rpc-upgrade">Upgrade Guide</a></li>
                                  </ul>
                                  <h5>Rackspace Private Cloud v11</h5>
                                  <ul>
@@ -48,7 +46,6 @@
                                    <li><a href="/docs/private-cloud/rpc/v11/rpc-ops/">Operations Guide</a></li>
                                    <li><a href="/docs/private-cloud/rpc/v11/rpc-releasenotes">Release Notes</a></li>
                                    <li><a href="/docs/private-cloud/rpc/v11/rpc-swift">Standalone Object Storage Guide</a></li>
-                                   <li><a href="/docs/private-cloud/rpc/v11/rpc-upgrade">Upgrade Guide</a></li>
                                  </ul>
                              </div>
                          </div>


### PR DESCRIPTION
The upgrade guide is moving to the internal gh-pages site
since the upgrade process is only performed internally.